### PR TITLE
Raven can log when CI_Log lack write access.

### DIFF
--- a/application/libraries/MY_Log.php
+++ b/application/libraries/MY_Log.php
@@ -1,16 +1,26 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
-class MY_Log extends CI_Log {
+class MY_Log {
 
 	protected $_config;
 	protected $_raven;
 	protected $_raven_levels = array();
+	protected $_threshold = 1;
+	protected $_levels = array('ERROR' => '1', 'DEBUG' => '2',  'INFO' => '3', 'ALL' => '4');
 
 	public function __construct()
 	{
-		parent::__construct();
-
 		$this->config =& get_config();
+		
+		if (is_numeric($this->config['log_threshold']))
+		{
+			$this->_threshold = $this->config['log_threshold'];
+		}
+
+		if ($this->config['log_date_format'] != '')
+		{
+			$this->_date_fmt = $this->config['log_date_format'];
+		}
 		
 		// Environment check
 		if ( ! in_array(ENVIRONMENT, $this->config['raven_environments'])) return;
@@ -55,11 +65,6 @@ class MY_Log extends CI_Log {
 	{
 		// Environment check
 		if ( ! in_array(ENVIRONMENT, $this->config['raven_environments'])) return;
-		
-		if ($this->_enabled === FALSE)
-		{
-			return FALSE;
-		}
 
 		$level = strtoupper($level);
 


### PR DESCRIPTION
CodeIgniter lack proper abstractions in CI_Log by being a file based logger, so we shouldn't use it as a base. What happens in CI_Log is:

``` php
if ( ! is_dir($this->_log_path) OR ! is_really_writable($this->_log_path))
{
    $this->_enabled = FALSE;
}
```

This causes `write_log` to fail even though we will never write to disk. Ideally CodeIgniter would add a `Base_Log` that defines a common interface for loggers and doesn't expect a certain protocol to be use, but in the meanwhile we'll lift the few variables we need from `CI_Log` and have a plain object.
