### PR TITLE
Add $error_handler->registerShutdownFunction(); closes #3

### DIFF
--- a/application/libraries/MY_Log.php
+++ b/application/libraries/MY_Log.php
@@ -43,6 +43,7 @@ class MY_Log extends CI_Log {
 			$error_handler = new Raven_ErrorHandler($this->_raven);
 			$error_handler->registerErrorHandler();
 			$error_handler->registerExceptionHandler();
+			$error_handler->registerShutdownFunction();
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
It logs fatal errors logged by `register_shutdown_function`. https://github.com/getsentry/raven-php/blob/master/lib/Raven/ErrorHandler.php#L98
